### PR TITLE
Fixed NoneType handling in encode function

### DIFF
--- a/dbf2csv/main.py
+++ b/dbf2csv/main.py
@@ -55,7 +55,7 @@ def __convert(input_file_path, output_file, args):
         """
         if not isinstance(x, str):
             # DBF converts columns into non-str like int, float
-            x = str(x)
+            x = str(x) if x is not None else ''
         return x.encode(args.input_encoding).decode(args.output_encoding)
 
     try:


### PR DESCRIPTION
This PR is a simple change that fixes the way dbf2csv handles NoneType returns from dbfread.

Prior to my change, `encode_decode` would convert any NoneTypes to strings, which returns `'None'` instead of an empty string like one might expect.

My change explicitly converts NoneTypes to empty strings, since that makes the most sense for a CSV.